### PR TITLE
Removing blockscout explorer from front-page

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
         <br />
         <li class="nav-item"><a target="_blank" href="https://stats.goerli.net">Network Status ^</a></li>
         <li class="nav-item"><a target="_blank" href="https://goerli-faucet.slock.it/">Simple Faucet ^</a> | <a target="_blank" href="https://faucet.goerli.mudit.blog">Social Faucet ^</a></li>
-        <li class="nav-item"><a target="_blank" href="https://goerli.etherscan.io">Etherscan ^</a> | <a target="_blank" href="https://blockscout.com/eth/goerli">Blockscout ^</a></li>
+        <li class="nav-item"><a target="_blank" href="https://goerli.etherscan.io">Etherscan ^</a></li>
         <li class="nav-item"><a target="_blank" href="https://github.com/goerli/testnet">Configuration ^</a> | <a target="_blank" href="https://mudit.blog/getting-started-goerli-testnet/">Quickstart ^</a></li>
     </ul>
     <section>


### PR DESCRIPTION
Blockscout no longer offers Goërli option.